### PR TITLE
Add worker skills and management page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ resources:
   workers: 3  # Numero di operai disponibili
   hours_per_day: 8  # Ore di lavoro per operaio al giorno
   default_cycle_time: 0.10  # Tempo di default per pezzo (in ore) se non specificato
+  workers_file: "./data/workers.yaml"  # File YAML con dati operai
 
 # Configurazione dashboard
 dashboard:

--- a/data/workers.yaml
+++ b/data/workers.yaml
@@ -1,0 +1,15 @@
+- id: 1
+  name: Operaio 1
+  hours_per_day: 8
+  skills:
+    - default
+- id: 2
+  name: Operaio 2
+  hours_per_day: 8
+  skills:
+    - default
+- id: 3
+  name: Operaio 3
+  hours_per_day: 8
+  skills:
+    - default

--- a/domain/models.py
+++ b/domain/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, date
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 from enum import Enum
 
 
@@ -45,6 +45,7 @@ class Worker:
     id: int
     name: str
     hours_per_day: float = 8.0
+    skills: Set[str] = field(default_factory=set)
     # Dizionario che mappa date a ore disponibili
     availability: Dict[date, float] = field(default_factory=dict)
     
@@ -95,3 +96,45 @@ class WorkSchedule:
     def get_day_schedule(self, day: date) -> List[Allocation]:
         """Restituisce le allocazioni per un giorno specifico"""
         return [a for a in self.allocations if a.allocation_date == day]
+
+
+def load_workers_from_yaml(path: str) -> List[Worker]:
+    """Carica gli operai da un file YAML"""
+    import yaml
+    import os
+
+    if not os.path.exists(path):
+        return []
+
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or []
+
+    workers: List[Worker] = []
+    for item in data:
+        worker = Worker(
+            id=item.get("id"),
+            name=item.get("name"),
+            hours_per_day=item.get("hours_per_day", 8.0),
+            skills=set(item.get("skills", [])),
+        )
+        workers.append(worker)
+
+    return workers
+
+
+def save_workers_to_yaml(workers: List[Worker], path: str) -> None:
+    """Salva gli operai in un file YAML"""
+    import yaml
+
+    data = [
+        {
+            "id": w.id,
+            "name": w.name,
+            "hours_per_day": w.hours_per_day,
+            "skills": sorted(list(w.skills)),
+        }
+        for w in workers
+    ]
+
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f, allow_unicode=True)

--- a/main.py
+++ b/main.py
@@ -49,19 +49,28 @@ async def run_agents(config_path: str = "config.yaml"):
     data_dir = Path(excel_path).parent
     os.makedirs(data_dir, exist_ok=True)
     
-    # Crea gli operai
+    # Carica gli operai dal file YAML se disponibile
+    from domain.models import load_workers_from_yaml
+
+    workers_file = config["resources"].get("workers_file")
     workers = []
-    num_workers = config["resources"]["workers"]
-    hours_per_day = config["resources"]["hours_per_day"]
-    
-    for i in range(1, num_workers + 1):
-        worker = Worker(
-            id=i,
-            name=f"Operaio {i}",
-            hours_per_day=hours_per_day
-        )
-        workers.append(worker)
-    
+
+    if workers_file and os.path.exists(workers_file):
+        workers = load_workers_from_yaml(workers_file)
+
+    if not workers:
+        # Fallback: crea operai di default
+        num_workers = config["resources"]["workers"]
+        hours_per_day = config["resources"]["hours_per_day"]
+
+        for i in range(1, num_workers + 1):
+            worker = Worker(
+                id=i,
+                name=f"Operaio {i}",
+                hours_per_day=hours_per_day,
+            )
+            workers.append(worker)
+
     logger.info(f"Creati {len(workers)} operai")
     
     # Crea il monitor Excel

--- a/planner/algorithms.py
+++ b/planner/algorithms.py
@@ -126,12 +126,21 @@ class Scheduler:
                 if remaining_hours <= 0:
                     break
                 
-                # Trova l'operaio con più disponibilità per questo giorno
+                # Trova gli operai che conoscono il codice
+                eligible_workers = [
+                    w for w in self.workers
+                    if not w.skills or order.code in w.skills
+                ]
+
+                # Ordina per disponibilità
                 workers_sorted = sorted(
-                    self.workers,
+                    eligible_workers,
                     key=lambda w: w.get_available_hours(day),
                     reverse=True
                 )
+
+                if not workers_sorted:
+                    continue
                 
                 for worker in workers_sorted:
                     allocated = worker.allocate_hours(day, remaining_hours)

--- a/planner/worker_agent.py
+++ b/planner/worker_agent.py
@@ -49,6 +49,10 @@ class WorkerAgent:
         order_code = event.order_code
         work_hours = event.work_hours
         due_date = event.due_date
+
+        # Verifica se l'operaio conosce il codice
+        if self.worker.skills and order_code not in self.worker.skills:
+            return
         
         # Aggiungi l'ordine alle offerte attive
         self.active_bids.add(order_code)


### PR DESCRIPTION
## Summary
- store workers in YAML and reference it from config
- load workers with skills in main and dashboard
- add skills field for workers and helpers to load/save workers
- filter scheduling and bidding by worker skills
- show assigned worker on orders tab and add worker management tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6880d68e4cd0832d9e77fc4b0e50437a