### PR TITLE
Fix workers multiselect bug and cleanup imports

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,7 +15,6 @@ import yaml
 import plotly.express as px
 import plotly.graph_objects as go
 
-from domain.events import Event, EventType, ScheduleUpdated, ProgressUpdate
 from domain.events import (
     Event,
     EventType,
@@ -745,9 +744,10 @@ class Dashboard:
                 with st.expander(f"{w.name} (ID {w.id})"):
                     with st.form(f"edit_worker_{w.id}"):
                         skill_options = sorted(self.orders.keys())
+                        default_skills = [s for s in sorted(w.skills) if s in skill_options]
                         selected = st.multiselect(
                             "Competenze", options=skill_options,
-                            default=sorted(w.skills), key=f"skills_{w.id}"
+                            default=default_skills, key=f"skills_{w.id}"
                         )
                         saved = st.form_submit_button("Salva")
                     if saved:


### PR DESCRIPTION
## Summary
- remove duplicate domain.events import in dashboard
- fix worker skills default selection filtering

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6881de9052b4832dbf28c952a358a7ff