### PR TITLE
Use document number as main key

### DIFF
--- a/data_loader/excel_monitor.py
+++ b/data_loader/excel_monitor.py
@@ -83,7 +83,7 @@ class ExcelMonitor:
     
     def _detect_changes(self, current_orders: List[Order]) -> None:
         """Rileva cambiamenti negli ordini e genera eventi appropriati"""
-        current_order_dict = {order.code: order for order in current_orders}
+        current_order_dict = {order.doc_number: order for order in current_orders}
         current_codes = set(current_order_dict.keys())
         known_codes = set(self.known_orders.keys())
         
@@ -93,11 +93,11 @@ class ExcelMonitor:
             order = current_order_dict[code]
             event = OrderCreated(
                 order_code=order.code,
+                doc_number=order.doc_number,
                 description=order.description,
                 ordered_qty=order.ordered_qty,
                 consumed_qty=order.consumed_qty,
                 cycle_time=order.cycle_time,
-                doc_number=order.doc_number,
                 doc_date=order.doc_date,
                 due_date=order.due_date,
                 priority_manual=order.priority_manual
@@ -118,6 +118,7 @@ class ExcelMonitor:
                 
                 event = OrderUpdated(
                     order_code=current.code,
+                    doc_number=current.doc_number,
                     ordered_qty=current.ordered_qty,
                     consumed_qty=current.consumed_qty,
                     due_date=current.due_date,

--- a/domain/events.py
+++ b/domain/events.py
@@ -25,18 +25,19 @@ class Event:
 
 class OrderEvent(Event):
     """Evento relativo a un ordine"""
-    
-    def __init__(self, order_code: str, type: EventType = None, timestamp: datetime = None):
+
+    def __init__(self, order_code: str, doc_number: str, type: EventType = None, timestamp: datetime = None):
         super().__init__(type=type, timestamp=timestamp or datetime.now())
         self.order_code = order_code
+        self.doc_number = doc_number
 
 
 class OrderUpdated(OrderEvent):
     """Evento emesso quando un ordine viene aggiornato"""
-    
-    def __init__(self, order_code: str, ordered_qty: int, consumed_qty: int, due_date: datetime, 
+
+    def __init__(self, order_code: str, doc_number: str, ordered_qty: int, consumed_qty: int, due_date: datetime,
                  priority_manual: Optional[int] = None, timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.ORDER_UPDATED, timestamp=timestamp)
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.ORDER_UPDATED, timestamp=timestamp)
         self.ordered_qty = ordered_qty
         self.consumed_qty = consumed_qty
         self.due_date = due_date
@@ -45,16 +46,15 @@ class OrderUpdated(OrderEvent):
 
 class OrderCreated(OrderEvent):
     """Evento emesso quando un nuovo ordine viene creato"""
-    
-    def __init__(self, order_code: str, description: str, ordered_qty: int, consumed_qty: int, 
-                 cycle_time: float, doc_number: str, doc_date: datetime, due_date: datetime,
+
+    def __init__(self, order_code: str, doc_number: str, description: str, ordered_qty: int, consumed_qty: int,
+                 cycle_time: float, doc_date: datetime, due_date: datetime,
                  priority_manual: Optional[int] = None, timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.ORDER_CREATED, timestamp=timestamp)
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.ORDER_CREATED, timestamp=timestamp)
         self.description = description
         self.ordered_qty = ordered_qty
         self.consumed_qty = consumed_qty
         self.cycle_time = cycle_time
-        self.doc_number = doc_number
         self.doc_date = doc_date
         self.due_date = due_date
         self.priority_manual = priority_manual
@@ -62,19 +62,19 @@ class OrderCreated(OrderEvent):
 
 class BidRequest(OrderEvent):
     """Richiesta di offerta per un ordine"""
-    
-    def __init__(self, order_code: str, work_hours: float, due_date: datetime, timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.BID_REQUEST, timestamp=timestamp)
+
+    def __init__(self, order_code: str, doc_number: str, work_hours: float, due_date: datetime, timestamp: datetime = None):
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.BID_REQUEST, timestamp=timestamp)
         self.work_hours = work_hours
         self.due_date = due_date
 
 
 class BidResponse(OrderEvent):
     """Risposta a una richiesta di offerta"""
-    
-    def __init__(self, order_code: str, worker_id: int, capacity: float, proposed_dates: Dict[date, float], 
+
+    def __init__(self, order_code: str, doc_number: str, worker_id: int, capacity: float, proposed_dates: Dict[date, float],
                  timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.BID_RESPONSE, timestamp=timestamp)
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.BID_RESPONSE, timestamp=timestamp)
         self.worker_id = worker_id
         self.capacity = capacity
         self.proposed_dates = proposed_dates
@@ -82,18 +82,18 @@ class BidResponse(OrderEvent):
 
 class AllocationAward(OrderEvent):
     """Assegnazione di un ordine a un operaio"""
-    
-    def __init__(self, order_code: str, worker_id: int, allocations: Dict[date, float], timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.ALLOCATION_AWARD, timestamp=timestamp)
+
+    def __init__(self, order_code: str, doc_number: str, worker_id: int, allocations: Dict[date, float], timestamp: datetime = None):
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.ALLOCATION_AWARD, timestamp=timestamp)
         self.worker_id = worker_id
         self.allocations = allocations
 
 
 class ProgressUpdate(OrderEvent):
     """Aggiornamento del progresso di un ordine"""
-    
-    def __init__(self, order_code: str, worker_id: int, qty_done: int, allocation_date: date, timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.PROGRESS_UPDATE, timestamp=timestamp)
+
+    def __init__(self, order_code: str, doc_number: str, worker_id: int, qty_done: int, allocation_date: date, timestamp: datetime = None):
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.PROGRESS_UPDATE, timestamp=timestamp)
         self.worker_id = worker_id
         self.qty_done = qty_done
         self.allocation_date = allocation_date
@@ -101,9 +101,9 @@ class ProgressUpdate(OrderEvent):
 
 class PriorityChange(OrderEvent):
     """Cambio di priorità di un ordine"""
-    
-    def __init__(self, order_code: str, new_priority: int, timestamp: datetime = None):
-        super().__init__(order_code=order_code, type=EventType.PRIORITY_CHANGE, timestamp=timestamp)
+
+    def __init__(self, order_code: str, doc_number: str, new_priority: int, timestamp: datetime = None):
+        super().__init__(order_code=order_code, doc_number=doc_number, type=EventType.PRIORITY_CHANGE, timestamp=timestamp)
         self.new_priority = new_priority
 
 

--- a/domain/models.py
+++ b/domain/models.py
@@ -64,7 +64,7 @@ class Worker:
 @dataclass
 class Allocation:
     """Rappresenta un'allocazione di lavoro per un ordine a un operaio"""
-    order_code: str
+    doc_number: str
     worker_id: int
     allocation_date: date
     hours: float
@@ -73,7 +73,7 @@ class Allocation:
     @property
     def key(self) -> str:
         """Chiave univoca per l'allocazione"""
-        return f"{self.order_code}_{self.worker_id}_{self.allocation_date.isoformat()}"
+        return f"{self.doc_number}_{self.worker_id}_{self.allocation_date.isoformat()}"
 
 
 @dataclass
@@ -89,9 +89,9 @@ class WorkSchedule:
         """Restituisce le allocazioni per un operaio specifico"""
         return [a for a in self.allocations if a.worker_id == worker_id]
     
-    def get_order_schedule(self, order_code: str) -> List[Allocation]:
+    def get_order_schedule(self, doc_number: str) -> List[Allocation]:
         """Restituisce le allocazioni per un ordine specifico"""
-        return [a for a in self.allocations if a.order_code == order_code]
+        return [a for a in self.allocations if a.doc_number == doc_number]
     
     def get_day_schedule(self, day: date) -> List[Allocation]:
         """Restituisce le allocazioni per un giorno specifico"""


### PR DESCRIPTION
## Summary
- switch allocations and events to use `doc_number` as unique key
- improve worker assignment strategy
- adjust dashboard and Excel loader for new key

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6881f0b15fd8832d8e31a99e0a05f500